### PR TITLE
Editorial: Fixed typos in champion.md

### DIFF
--- a/champion.md
+++ b/champion.md
@@ -49,7 +49,7 @@ To work through the stage process, a tracking issue in the GitHub repository can
 
 ## Moving through the stages in committee
 
-Building on the [authoritiative documentation for the stage process](https://tc39.es/process-document/), this section builds on that with some additional practical advice for activities which may be helpful at various stages.
+Building on the [authoritative documentation for the stage process](https://tc39.es/process-document/), this section builds on that with some additional practical advice for activities which may be helpful at various stages.
 
 Stage advancement happens in TC39 meetings, when a proposal is presented to the committee, based on consensus of the committee that the proposal should advance to the stage. See [presentation advice](https://github.com/tc39/how-we-work/blob/master/presenting.md) for more details.
 
@@ -69,7 +69,7 @@ Acceptance signifies:
 Leading up to Stage 1,
 - **Identify a champion (or champion group) in committee**. Unfortunately, TC39 doesn't have a comprehensive way for non-committee members to find committee mentors/champions for their proposals, but existing forums include [es-discuss mailing list](https://esdiscuss.org); another is the IRC channel #tc39 on Freenode ([instructions](https://freenode.net/kb/answer/chat)). Many TC39 delegates can be found on Twitter as well.
 - **Write an explainer**. See [explainer.md](https://github.com/tc39/how-we-work/pull/46) for advice on how to write the introductory document to fulfill the rest of the Stage 1 requirements.
-- **Prepare a presentation** to get the committee thinking about what they want to do in this design area, and if you have specific ideas, make the case for moving in that direction. See [presentating.md](https://github.com/tc39/how-we-work/blob/master/presenting.md) for advice about presentations.
+- **Prepare a presentation** to get the committee thinking about what they want to do in this design area, and if you have specific ideas, make the case for moving in that direction. See [presenting.md](https://github.com/tc39/how-we-work/blob/master/presenting.md) for advice about presentations.
 
 Stage 1 represents more that the committee is thinking into this design space, rather than any sort of consensus on moving JavaScript in a particular direction.
 


### PR DESCRIPTION
Fixed a couple of possible typos in `champion.md`:
* `authoritiative` -> `authoritative`
* `presentating` -> `presenting`

If the changes are inaccurate, please let me know and I'll make the rectifications asap (^_^)