### PR TITLE
Summarize Invited Expert process

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For an introduction to getting involved in TC39, see [CONTRIBUTING.md](https://g
 
 - Admin
   - [Becoming a TC39 delegate](join-tc39.md)
+  - [Becoming a TC39 invited expert](invited-expert.md)
   - [TC39 management](management.md)
   - [TC39 and IP](ip.md)
 

--- a/invited-expert.md
+++ b/invited-expert.md
@@ -1,0 +1,35 @@
+# How to become a TC39 Invited Expert
+
+## Overview
+
+A TC39 ***Invited Expert*** is a person who is invited to participate in TC39.  They have access to the Reflector and can attend meetings and participate in discussion similar to normal delegates.
+
+The purpose of this role, as agreed with Ecma, is to allow individuals working on strategic open source projects to fully participate in the committee without being employed by an Ecma member.  For example, project members representing Babel and Rollup.
+
+## Joining Process
+
+1. A delegate from an Ecma member acting as the ***sponsor*** proposes an individual to become an Invited Expert by completing the *TC39 Invited Expert Nomination Form* on TC39 Admin & Business repo.  This includes stating the reason for the nomination.
+
+1. There are 7 days for other delegates to provide supporting statements or objections on the issue.
+
+1. The Chairs review the nomination responses and decide whether to:
+   - approve (recording the conditions of participation such as time-limits or roles)
+   - reject
+   - ask the committee in the next plenary session
+
+1. Once approved, the Chairs request approval from the Ecma Secretariat.
+
+1. Once the Ecma Secretariat has approved and the Invited Expert has signed the *Ecma Invited Expert Form*, the Chairs will execute the onboarding checklist.
+
+## Leaving Process
+
+1. The leaving process for an Invited Expert will be triggered by either:
+   - the individual notifying the Chairs
+   - the sponsor notifying the Chairs
+   - the Chairs determining that the conditions of participation have expired
+
+1. Chairs will post the off-boarding form on [the Admin & Business repo](https://github.com/tc39/Admin-and-Business/issues) and send an email to the individual and the sponsor.
+
+1. There are 7 days for other delegates to re-propose the individual should they wish to extend their tenure as an invited expect.  Renewal is handled in the same way as the Joining Process.
+
+1. Assuming there is no renewal, the Chairs execute the off-boarding checklist.


### PR DESCRIPTION
A lot of work went into defining the Invited Expert role with Ecma and producing the associated guidelines and forms.  The remaining part is to document how the process operates.

https://github.com/tc39/Reflector/issues/187

I've tried to summarize the basic steps here.  It's missing links to the actual forms - I will add those later.