### PR TITLE
fix incorrect & normalize matrix channel links to be human-readable

### DIFF
--- a/matrix-guide.md
+++ b/matrix-guide.md
@@ -114,11 +114,11 @@ Suggested settings to change:
 [Element]: https://element.io/
 [list of clients]: https://matrix.org/clients/
 
-[#tc39-general]: https://matrix.to/#/!wbACpffbfxANskIFZq:matrix.org
-[#tc39-delegates]: https://matrix.to/#/!WgJwmjBNZEXhJnXHXw:matrix.org
-[#temporaldeadzone]: https://matrix.to/#/!RKGOsXKqdKdyWOiTEA:matrix.org
-[#tc39-implementers]: https://matrix.to/#/!hmsRHUEXriRovkvcin:matrix.org
-[#tc39-ecma402]: https://matrix.to/#/!hmsRHUEXriRovkvcin:matrix.org
-[#tc39-beginners]: https://matrix.to/#/!OXhgybpQzCtnugpzuz:matrix.org
-[#tc39-inclusion]: https://matrix.to/#/!DgpygRnlCHLTRbahDa:matrix.org
-[#tc39-website]: https://matrix.to/#/!hmsRHUEXriRovkvcin:matrix.org
+[#tc39-general]: https://matrix.to/#tc39-general:matrix.org
+[#tc39-delegates]: https://matrix.to/#tc39-delegates:matrix.org
+[#temporaldeadzone]: https://matrix.to/#temporaldeadzone:matrix.org
+[#tc39-implementers]: https://matrix.to/#tc39-implementers:matrix.org
+[#tc39-ecma402]: https://matrix.to/#tc39-ecma402:matrix.org
+[#tc39-beginners]: https://matrix.to/#tc39-beginners:matrix.org
+[#tc39-inclusion]: https://matrix.to/#tc39-inclusion:matrix.org
+[#tc39-website]: https://matrix.to/#tc39-website:matrix.org

--- a/matrix-guide.md
+++ b/matrix-guide.md
@@ -114,11 +114,11 @@ Suggested settings to change:
 [Element]: https://element.io/
 [list of clients]: https://matrix.org/clients/
 
-[#tc39-general]: https://matrix.to/#tc39-general:matrix.org
-[#tc39-delegates]: https://matrix.to/#tc39-delegates:matrix.org
-[#temporaldeadzone]: https://matrix.to/#temporaldeadzone:matrix.org
-[#tc39-implementers]: https://matrix.to/#tc39-implementers:matrix.org
-[#tc39-ecma402]: https://matrix.to/#tc39-ecma402:matrix.org
-[#tc39-beginners]: https://matrix.to/#tc39-beginners:matrix.org
-[#tc39-inclusion]: https://matrix.to/#tc39-inclusion:matrix.org
-[#tc39-website]: https://matrix.to/#tc39-website:matrix.org
+[#tc39-general]: https://matrix.to/#/#tc39-general:matrix.org
+[#tc39-delegates]: https://matrix.to/#/#tc39-delegates:matrix.org
+[#temporaldeadzone]: https://matrix.to/#/#temporaldeadzone:matrix.org
+[#tc39-implementers]: https://matrix.to/#/#tc39-implementers:matrix.org
+[#tc39-ecma402]: https://matrix.to/#/#tc39-ecma402:matrix.org
+[#tc39-beginners]: https://matrix.to/#/#tc39-beginners:matrix.org
+[#tc39-inclusion]: https://matrix.to/#/#tc39-inclusion:matrix.org
+[#tc39-website]: https://matrix.to/#/#tc39-website:matrix.org


### PR DESCRIPTION
Before this change, the links for&hellip;

- `#tc39-implementers`
- `#tc39-ecma402`
- `#tc39-website`

&hellip; were all pointing to the same place (https://matrix.to/#/!hmsRHUEXriRovkvcin:matrix.org).

We appear to have missed this when we reviewed this part of the guide the other day (https://github.com/tc39/how-we-work/pull/89).

I am not entirely sure what that URL is to, but it seems like it could be to the whole TC39 Matrix &ldquo;Space&rdquo;?

While doing this, I found out that there is a way to make the links to these channels human-readable. The advantage to this is that the names of the rooms are populated with their actual names (as opposed to a random character sequence) while the element invitation page is loading.

It seems like these shareable Matrix links can be acquired via https://matrix.to/ w/o needing room invitation privileges, however, I was not able to figure out how to generate a human-readable shareable link to the entire space, which should probably be linked to separately (there does not seem to be a section of the guide expanding upon the &ldquo;spaces&rdquo; concept).

/cc @ryzokuken