### PR TITLE
Suggest matrixlogs.bakkot.com in matrix-guide

### DIFF
--- a/matrix-guide.md
+++ b/matrix-guide.md
@@ -138,3 +138,4 @@ Suggested settings to change:
 1. In Security & Privacy, set "Who can access this room?" to "Anyone who knows the room's link, including guests". Also set "Who can read history?" to "Anyone".
 1. In Advanced, copy the internal room ID. Go back to General, and add a link to the logs in the room topic, like so: "Public logs at https://view.matrix.org/room/!WgJwmjBNZEXhJnXHXw:matrix.org/".
 1. Ask one of the chairs to add the room to the [TC39 space](https://app.element.io/#/room/!hmsRHUEXriRovkvcin:matrix.org).
+1. Once the room is in the TC39 space it will automatically get logged on https://matrixlogs.bakkot.com/. You can change the topic to refer to the relevant channel there instead.


### PR DESCRIPTION
I really, really dislike the `view.matrix.org` logs: they're very slow, they're not searchable, and you can't link to a specific line in them - the best you can do is get a `matrix.to` link, which requires a minimum of three clicks to get to the actual content even if you're already logged in. It's just a terrible experience all around.

I think my logs are better. They're faster, they're searchable, they're linkable. And I just updated it to pick up everything in the TC39 space with world-readable history, so it should pick up new rooms automatically.

So I'd like to suggest we default to using [my logs](https://matrixlogs.bakkot.com/) instead.