### PR TITLE
meta: correct contributing link branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Ecma International's TC39 is the standards committee which defines ECMAScript (J
 
 This repository is an early work in progress!
 
-For an introduction to getting involved in TC39, see [CONTRIBUTING.md](https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md).
+For an introduction to getting involved in TC39, see [CONTRIBUTING.md](https://github.com/tc39/ecma262/blob/HEAD/CONTRIBUTING.md).
 
 # Table of Contents
 


### PR DESCRIPTION
Correct the contributing link branch from `master` to `HEAD` to target the latest default branch since [ecma262](https://github.com/tc39/ecma262)'s default branch has changed.