### PR TITLE
Clean up headings in terminology.md.

### DIFF
--- a/terminology.md
+++ b/terminology.md
@@ -18,28 +18,27 @@ Anatomy of a good definition:
 
 These are common terms used while discussing language features.
 
-### Bikeshedding
+## Bikeshedding
 
-#### Definition
-
+### Definition
 The process of discussing a trivial matter at the expense of the topic that actually
 needs discussion. This can take time away from important topics, and its important to catch
 ourselves if we start bikeshedding!
 
-#### Example
+### Example
 We were supposed to discuss how this new proposal should work, but we spent the entire time discussing what the
 name should be. We should avoid such bikeshedding.
 
-#### References
+### References
 [wikipedia](https://en.wiktionary.org/wiki/bikeshedding)
 
-### Brand Check
+## Brand check
 
-#### Definition
+### Definition
 Brand check ("brand" as in a mark, or a brand made with a branding iron) is a term used by TC39
 to describe a check against a unique datatype whose creation is controlled by a piece of code.
 
-#### Example
+### Example
 One example of this is built in JavaScript datatypes, which are unique and cannot be made in user
 space. `Array.isArray` is an example of a brand check. For reference see [this
 discussion](https://esdiscuss.org/topic/tostringtag-spoofing-for-null-and-undefined#content-3).
@@ -82,16 +81,16 @@ class Query {
 }
 ```
 
-#### References
+### References
 - [ES Discuss comment](https://esdiscuss.org/topic/tostringtag-spoofing-for-null-and-undefined#content-3)
 - [Clarifying comment on GitHub](https://github.com/tc39/how-we-work/pull/30#issuecomment-391588889)
 
-### Tail call, PTC (proper tail call), STC (syntactic tail call)
+## Tail call, PTC (proper tail call), STC (syntactic tail call)
 
-#### Definition
+### Definition
 A _tail call_ is a call which occurs as the final operation of a function and whose value is returned immediately. It is possible for such a call to reuse or replace the current stack frame, in which case it is known as a _proper_ tail call (PTC). PTC semantics are part of the standard as of ES6, but their implementation in various engines has been fraught with controversy. In particular, reluctance to the automatic nature of PTC led to an alternative _syntactic_ tail call (STC) proposal, in which users would consciously choose this behavior by means of a keyword. PTC is currently only shipped by JSC, while STC remains an open but inactive proposal.
 
-#### Example
+### Example
 ```js
 function factorial(n) {
   // Not a tail call -- we still need to multiply by n after the call
@@ -109,20 +108,20 @@ function factorial(n, acc = 1) {
 }
 ```
 
-#### References
+### References
 - [PTC specification](https://tc39.es/ecma262/#sec-tail-position-calls)
 - [STC proposal](https://github.com/tc39/proposal-ptc-syntax)
 - [Wikipedia](https://en.wikipedia.org/wiki/Tail_call)
 
-### Temporal dead zone (TDZ)
+## Temporal dead zone (TDZ)
 
-#### Definition
+### Definition
 Refers to a period of time during which a variable has been declared, but has
 not been assigned, and is therefore unavailable. This results in a ReferenceError. This happens when
 a `const` or a `let` is defined in the scope, but not yet. This is different from `var`, which will
 return undefined. Here is an example:
 
-#### Example
+### Example
 ```javascript
 console.log(bar) // ReferenceError TDZ
 console.log(baz) // undefined
@@ -134,62 +133,62 @@ console.log(bar) // 1
 console.log(baz) // 2
 ```
 
-#### References
+### References
 - [Let and Const Declarations](https://tc39.es/ecma262/#sec-let-and-const-declarations) -- the ECMAScript specification
 - [Temporal Dead Zone](https://wesbos.com/temporal-dead-zone/) -- blog post by Wes Bos which describes the term
 
-### Cover grammar
+## Cover grammar
 
-#### Definition
+### Definition
 A "cover grammar" is a technique used in the JavaScript grammar to remain context free and unambiguous when parsing from left to right with only one token of lookahead, while later tokens might lead to syntactic restrictions for earlier ones. Informally, one grammar is said to "cover" another if the second grammar is a subset of the first, with a corresponding subset of corresponding parse trees.
 
-#### Example
+### Example
 The [CoverParenthesizedExpressionAndArrowParameterList](https://tc39.es/ecma262/#prod-CoverParenthesizedExpressionAndArrowParameterList) production in the ECMAScript specification allows expressions and destructuring parameters of arrow functions to be interpreted together. If a `=>` is reached, the expression is reinterpreted as arrow function parameters, with additional restrictions applied.
 
-#### References
+### References
 The definition of [covering](https://tc39.es/ecma262/#sec-syntactic-grammar) in the ECMAScript specification, used to check whether it's valid to reinterpret one grammatical production as another.
 
-### Web compatibility/"Don't break the web"
+## Web compatibility/"Don't break the web"
 
-#### Definition
+### Definition
 A change to JavaScript is considered "**web compatible**" if it preserves the current behavior of existing websites. If it changes the behavior of existing websites, it's considered to "**break the web**".
 
 The definition here is a bit fuzzy and empirical--it's always possible to construct a website which will break under any particular change or addition to JavaScript, and the key is how common the broken websites are. If too many websites break, then web browsers will refuse to ship the change.
 
 **"Don't break the web"** is a shared goal of TC39 and all web standards bodies: We aim to preserve web compatibility as we evolve the language. Even if a change would be convenient for developers, it's not worth it if we hurt lots of users in the process!
 
-#### Example
+### Example
 There was an effort to add a method `Array.prototype.contains`. However, this broke many websites ([reference](https://esdiscuss.org/topic/having-a-non-enumerable-array-prototype-contains-may-not-be-web-compatible)). As a result, the method was named as [`Array.prototype.includes`](https://github.com/tc39/Array.prototype.includes/) instead.
 
 ----
 
 ES2015 changed RegExp semantics to make `RegExp.prototype` not a RegExp instance, and to make `RegExp.prototype.sticky` a getter which threw when accessed on a non-RegExp. It turned out that this change was not web-compatible--data from Chrome showed that .05% of web page loads hit this case. As a result, TC39 agreed to make an allowance in `RegExp.prototype.sticky` and similar getters to permit `RegExp.prototype` as a receiver. See [this slide deck](https://docs.google.com/presentation/d/1BZiysQL4YMXgexwTmcZTFOD0nxGSAGz7PbzAotoDiGw/edit#slide=id.p) for details.
 
-#### Sources
+### References
 - [#SmooshGate FAQ](https://developers.google.com/web/updates/2018/03/smooshgate) by Mathias Bynens
 
-### Meta-object protocol
+## Meta-object protocol
 
-#### Definition
+### Definition
 "Meta-object protocol" (often abbreviated as "MOP") is a fancy term to describe the basic operations in an object system. For example, in JavaScript, getting a property is one operation in the meta-object protocol. The term originated in the Lisp community, and is used in TC39 because we can take a lot of inspiration from the developments in the Common Lisp Object System.
 
-#### Example
+### Example
 Each operation in JavaScript's meta-object protocol is a method in [Reflect](https://tc39.es/ecma262/#sec-reflect-object), and each of these is also a [Proxy](https://tc39.es/ecma262/#sec-proxy-objects) trap.
 
 In the issue [Implement meta-object trap(s) to make an object's [[Prototype]] immutable](https://github.com/tc39/ecma262/issues/538), there is discussion about adding another fundamental object operation to freeze the prototype of an object (without performing a full `preventExtensions`). The title of the issue includes "meta-object" as a reference to the meta-object protocol, as the addition of this feature would require new Proxy and Reflect APIs.
 
-#### References
+### References
 - [The Art of the Metaobject Protocol](https://mitpress.mit.edu/books/art-metaobject-protocol) -- the book which introduced the term
 - [Object Internal Methods and Internal Slots](https://tc39.es/ecma262/#sec-object-internal-methods-and-internal-slots) -- JavaScript's meta-object protocol
 
-### Early errors
+## Early errors
 
-#### Definition
+### Definition
 An "early error" is an error which is thrown in the parsing phase of JavaScript code, before executing. This error is usually a `SyntaxError`, but other error types may be early errors as well. These early errors are produced even if the relevant code is not executed. Early errors are contrasted with runtime errors, which happen in the course of executing JavaScript code.
 
 When a JavaScript Script, Module or `eval`'d string contains an early error, none of it is run.
 
-#### Example
+### Example
 Multiple declarations of the same lexical variable produces an early error. For example, the following produces an early `SyntaxError`.
 
 ```js
@@ -204,31 +203,29 @@ let abc = 1;
 console.log(abd);  // runtime error
 ```
 
-#### References
+### References
 - [early error](https://tc39.es/ecma262/#early-error) defined in the ECMAScript specification editor's draft.
 
-### Options Bag
+## Options bag
 
-#### Definition
-
+### Definition
 A parameter value that is a JavaScript object with properties looked up eagerly. It is used to configure behavior of a function. Methods on the options bag object should be invoked with `undefined` as the default value for `this`
 
 The definition here is a bit fuzzy as some parameters are objects but not options bags.
 
-#### Example
-
+### Example
 ```js
 // options is an options bag
 const options =  { style: 'currency', currency: 'EUR' };
 new Intl.NumberFormat('de-DE', options);
 ```
 
-### Memoization
+## Memoization
 
-#### Definition
+### Definition
 "Memoization" is an optimization technique to reduce the run time of a program by using a cache to store results and avoid recomputation. In essence, it is a trade-off of space in exchange for time.
 
-#### Example
+### Example
 Non-memoized Fibonacci
 ```js
 function fib(num) {
@@ -248,118 +245,134 @@ function memoizedFib(num, memo = {}) {
 }
 ```
 
-#### References
+### References
 - [memoization](https://en.wikipedia.org/wiki/Memoization)
 
-### REPL
+## REPL
 
-#### Definition
+### Definition
 A read-eval-print loop, i.e. "REPL", is a interactive programming environment that allows a user to input a single expression whose result will be evaulated and returned. After each read-eval-print the environment returns to the initial read state, creating a loop, which is only terminated once the environment is closed.
 
-#### Example
+### Example
 In Firefox's Web Console the [command line interpreter](https://developer.mozilla.org/en-US/docs/Tools/Web_Console/The_command_line_interpreter) is a JavaScript REPL.
 
-#### References
+### References
 - [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)
-.....
 
-### Agent
-#### Definition
+## Agent
+
+### Definition
 An agent is a comprised of three things: a container for a set of job queues, related execution state, and an execution thread. The execution state is exclusive to the agent while the execution thread can be shared with other agents.
-#### Reference
+
+### References
 [ECMA262 Spec](https://tc39.es/ecma262/#sec-agents)
 
-### Realm
-#### Definition
+## Realm
+
+### Definition
 A realm consists of a set of [intrinsic](#Intrinsic) objects, an ECMAScript global environment, all of the ECMAScript code that is loaded within the scope of that global environment, and other associated state and resources (i.e. a global object and an associated set of [primordial](#Primordial) objects). Today, in the browser, realms can be created via same origin iframes.
-#### References
+
+### References
 [ECMA262 Spec](https://tc39.es/ecma262/#sec-code-realms)
 
-### Intrinsic
-#### Definition
+## Intrinsic
+
+### Definition
 A built-in value that is required by the ECMA262 specification.
 Where observable (e.g., as [primordial](#Primordial)), intrinsic objects are realm-specific while intrinsic symbols are shared by all realms.
 The specification itself references "well-known" intrinsics with special notation (%&lt;name>% for objects; @@&lt;name> for symbols).
-#### Example
+
+### Example
 %ForInIteratorPrototype% is the prototype of internal iterators that can be used to implement **`for (`** _Identifier_ **`in`** _Expression_ **`)`** statements
-#### Reference
+
+### References
 [ECMA262 (objects)](https://tc39.es/ecma262/#sec-well-known-intrinsic-objects),
 [ECMA262 (symbols)](https://tc39.es/ecma262/#sec-well-known-symbols)
 
-### Primordial
-#### Definition
+## Primordial
+
+### Definition
 An [intrinsic](#Intrinsic) value that is accessible to ECMAScript code and required to exist before any ECMAScript code runs.
-#### Example
+
+### Example
 %Array%, the initial value of a realm's Array constructor, is accessible as `Array`.
 
-### Effectively Undeniable
-#### Definition
+## Effectively undeniable
+
+### Definition
 A [primordial](#Primordial) value that is accessible to ECMAScript code without reference to named bindings other than those for prototype and property descriptor reflection (i.e., solely by syntax, `__proto__`, and primordial `getPrototypeOf`/`getOwnPropertyDescriptor`/`getOwnPropertyDescriptors` functions).
-#### Examples
+
+### Example
 %Array.prototype%, the initial value of a realm's Array prototype, is accessible as `[].__proto__`.
 %ThrowTypeError%, a realm's special TypeError-throwing function, is accessible as `(function(){ 'use strict'; return Object.getOwnPropertyDescriptor(arguments, 'callee').get; })()`.
 
-### Normative
-#### Definition
+## Normative
+
+### Definition
 Statements that constrain the observable behavior of implementations (i.e., the behavior that conforming implementations are allowed to exhibit).
 
-### SES
-#### Definition
+## SES
+
+### Definition
 Secure ECMAScript. A subset of ECMAScript.
-#### Reference
+
+### References
 [Useful diagram](https://github.com/Agoric/Jessie/blob/master/README.md)
 
-### Plenary
-#### Definition
+## Plenary
+
+### Definition
 Meeting of all available TC39 delegates. Occurs around 6 times a year.
 
-### Refactoring Hazard
-#### Definition
+## Refactoring hazard
+
+### Definition
 A seemingly simple change (i.e. thought to be semantically equivalent) that seems like a drop in replacement for an existing piece of code but has specific edge cases that make it not work as expected. As you refactor code from "old pattern" to "new pattern", it would be easy to cause unintentional effects (bugs, etc).
 
-### Reify
+## Reify
 
-#### Definition
+### Definition
 To make something a first-class concept in a language specification, such that it can be passed around, inspected, or manipulated by user code.
 
-#### Examples
+### Example
 - The C programming language reifies the concept of memory addresses with pointers.
 - ECMAScript reifies its own interpreter with `eval`.
 
-#### References
+### References
 - [Reification](https://en.wikipedia.org/wiki/Reification_(computer_science))
 
-### SDO (2 definitions)
-#### Definition (1)
+## SDO (2 definitions)
+
+### Definition (1)
 SDOs are syntax-directed operations in the ECMA-262 specification. These are the operations that are defined piecewise over the parse tree rather than by having a single algorithm. In other terms it is a particular style of algorithm in the specification.
 
-#### Example (1)
+### Example (1)
 Evaluation is an SDO because Evaluation is defined piecewise over several productions.
 
-#### References (1)
+### References (1)
 https://tc39.es/ecma262/multipage/notational-conventions.html#sec-algorithm-conventions-syntax-directed-operations
 
-#### Definition (2)
+### Definition (2)
 SDO is short for a Standards Developing Organization. 
 
-#### Examples (2)
+### Example (2)
 - ECMA
 - Unicode Consortium
 
-#### References (2)
+### References (2)
 https://en.wikipedia.org/wiki/Standards_organization
 
-TEMPLATE
-### [NAME HERE]
+# TEMPLATE
 
-#### Definition
+## {{Your term here}}
 
-#### Example
+### Definition
+### Example
+### References
 
-#### References
+# TODO
 
-
-TODO(goto): expand on each one of these terms, make them linkable.
+Expand on each one of these terms, make them linkable.
 
 * [hoisting](https://www.w3schools.com/js/js_hoisting.asp)
 * [IIFE](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression)
@@ -376,7 +389,6 @@ TODO(goto): expand on each one of these terms, make them linkable.
 * Coherency
 * Cross cutting concerns
 * 1JS position
-* Bikeshedding
 * Cornering
 * Frogboiled
 * Footguns
@@ -393,7 +405,6 @@ TODO(goto): expand on each one of these terms, make them linkable.
 * orthogonal
 * "Needs Consensus PR"
 * web reality
-* normative, non-normative
 * (meeting) minutes
 * editor, editor group, project editors
 * Test262
@@ -418,7 +429,7 @@ TODO(goto): expand on each one of these terms, make them linkable.
 
 These are common considerations that come up while discussing the technical merits of language features.
 
-## Parsing
+### Parsing
 
 * Syntax constraints (waldemar)
 * Parsing costs (backtracking, multiple parsing trees before getting tokens, e.g. pipeline
@@ -426,7 +437,7 @@ These are common considerations that come up while discussing the technical meri
 * Tokenization is greedy -- waldemar
 * Punctuation overload -- mark miller
 
-## On growing a language
+### On growing a language
 
 * Does it belong to the language? The extensible web manifesto.
 * Complexity Budget (herman, allen)
@@ -439,14 +450,14 @@ These are common considerations that come up while discussing the technical meri
 * Tennent’s Correspondence Principle (dherman)
 * Backwards compatibility (domenic, jordan)
 
-## Security
+### Security
 
 * object capabilities
 * Single origin policy
 * communication channel
 * tampering
 
-## Ecosystem
+### Ecosystem
 
 * Popular opinion (jordan, taking the feedback from the community constructively)
 * Polyfill considerations (libraries, frameworks, etc)


### PR DESCRIPTION
terminology.md is a bit hard to read at present, because we're skipping second-level headings and just using third- and fourth-level ones. Not sure if GH stylesheet changed somewhere along the line to make this worse, but I believe we either need to bump these headings up a level or add `<hr>`s after each entry.

This PR does the former, and while we're at it, ensures consistency of heading style throughout.