### PR TITLE
🔧 don't use textlint

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -47,6 +47,7 @@ jobs:
         uses: github/super-linter/slim@v4
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_NATURAL_LANGUAGE: false
           # Change if your main branch differs
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
textlint config in superlinter has some bogus rules (ES6 instead of ES2015, etc.) -- upon investigating configuring textlint, it's quite involved (and each individual rule is a separate dependency that needs to be installed via npm).  so... not necessarily something we can't do in the future, but the default is not workable