### PR TITLE
Add normative-conventions.md; document agreed-upon coercion rules

### DIFF
--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -6,7 +6,6 @@ None of these rules are inviolable, but you should have a good reason for any pa
 
 This list is very far from being complete.
 
-
 ## Number-taking inputs should reject `NaN`
 
 In any place which expects a number, receiving `NaN` - or anything which coerces to `NaN`, if coercion is performed - should throw a `RangeError`.
@@ -15,7 +14,6 @@ Note that some abstract operations, like [ToIntegerOrInfinity](https://tc39.es/e
 
 NB: This convention is new as of 2023, and most earlier parts of the language do not follow it.
 
-
 ## If an argument is expected, not getting it or getting `undefined` should throw a `TypeError`
 
 When there is a required argument, finding that it is explicitly `undefined` or is missing should throw a `TypeError` instead of attempting to coerce `undefined` to the expected type. This extends to values looked up in options bags, etc. This does not apply when there is a default value for the argument, since in that case it is not required.
@@ -23,4 +21,3 @@ When there is a required argument, finding that it is explicitly `undefined` or 
 This convention applies only to `undefined` specifically, and says nothing about the appropriate handling of values like `null` and `document.all`.
 
 NB: This convention is new as of 2023, and most earlier parts of the language do not follow it.
-

--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -6,32 +6,38 @@ None of these rules are inviolable, but you should have a good reason for any pa
 
 This list is very far from being complete.
 
+
+## Avoid coercing arguments to types other than Boolean
+
+If an argument to a built-in function is expected to be of a particular type other than Boolean, the function should throw a `TypeError` if called with a value not of that type, rather than performing coercion. This also applies to values read from options bags.
+
+For example, if a function takes a string and is called with a Number or an object, it should throw a `TypeError` rather than attempting to coerce those values to strings.
+
+NB: This convention is new as of 2024, and most earlier parts of the language do not follow it.
+
+
+## When required arguments are missing, throw
+
+In most cases, a built-in function being called with fewer arguments than expected is treated the same as being called with `undefined` for the remaining arguments. So per the above rule, when a built-in function is called with fewer arguments than expected it should throw a `TypeError` unless `undefined` is one of the types expected in that position. This also applies to values read from options bags.
+
+This does not apply when there is a default value for the argument in question, since in that case the argument is not required.
+
+NB: This convention is new as of 2024, and most earlier parts of the language do not follow it.
+
+
 ## Number-taking inputs should reject `NaN`
 
-In any built-in function which expects a non-NaN number (including as an option in an options bag), receiving `NaN` or anything which results in `NaN` after coercion is performed (such as by passing through `ToNumeric`, `ToPrimitive`, `ToNumber`, etc.) should cause a `RangeError` to be thrown.
+If an argument to a built-in function is expected to be a non-`NaN` Number (including as an option in an options bag), receiving `NaN` should cause a `RangeError` to be thrown.
 
-Note that some abstract operations, like [ToIntegerOrInfinity](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tointegerorinfinity), [ToIndex](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toindex), etc, will coerce inputs to Number and then further coerce the result, sometimes including mapping `NaN` to non-`NaN` values. So you'll need to coerce inputs to a Number using `ToNumber` before calling those operations, check for `NaN`, and then pass the resulting Number to the operation.
+NB: This convention is new as of 2024, and most earlier parts of the language do not follow it.
 
-An exception to this rule is functions which take optional numeric arguments: in that case, receiving `undefined` should be treated as the argument not being passed.
 
-NB: This convention is new as of 2023, and most earlier parts of the language do not follow it.
+## Integral-Number-taking inputs should reject non-integal arguments
 
-## Integer-taking inputs should reject non-integral numbers
-
-In any built-in function which expects an integral number (including as an option in an options bag), receiving a non-integral number or anything which results in a non-integral number after coercion is performed (such as by passing through `ToNumeric`, `ToPrimitive`, `ToNumber`, etc.) should cause a `RangeError` to be thrown.
-
-Note that some abstract operations, like [ToIntegerOrInfinity](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tointegerorinfinity), [ToIndex](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toindex), etc, will coerce inputs to Number and then further round the result. So you'll need to coerce inputs to a Number using `ToNumber` before calling those operations and then check for non-integral values, rather than using those operations.
+If an argument to a built-in function is expected to be a Number (including as an option in an options bag), receiving a non-integral Number should cause a `RangeError` to be thrown.
 
 For the purposes of this guideline `-0` is considered to be an integral number (specifically, 0).
 
 Some APIs intentionally round non-integral inputs, for example as an attempt to provide a best-effort behavior, rather than because the API fundamentally only makes sense with integers. This guideline does not apply to those cases.
 
-NB: This convention is new as of 2023, and most earlier parts of the language do not follow it.
-
-## If an argument is expected, not getting it or getting `undefined` should throw a `TypeError`
-
-When there is a required argument, finding that it is explicitly `undefined` or is missing should throw a `TypeError` instead of attempting to coerce `undefined` to the expected type. This extends to values looked up in options bags, etc. This does not apply when there is a default value for the argument, since in that case it is not required.
-
-This convention applies only to `undefined` specifically, and says nothing about the appropriate handling of values like `null` and `document.all`.
-
-NB: This convention is new as of 2023, and most earlier parts of the language do not follow it.
+NB: This convention is new as of 2024, and most earlier parts of the language do not follow it.

--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -28,7 +28,7 @@ If an argument to a built-in function is expected to be a non-`NaN` Number (incl
 
 NB: This convention is new as of 2024, and most earlier parts of the language do not follow it.
 
-## Integral-Number-taking inputs should reject non-integal arguments
+## Integral-Number-taking inputs should reject non-integral arguments
 
 If an argument to a built-in function is expected to be a Number (including as an option in an options bag), receiving a non-integral Number should cause a `RangeError` to be thrown.
 

--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -1,0 +1,26 @@
+# Normative conventions
+
+This document describes some of the conventions that we try to follow when designing new features. Sometimes old features don't follow these; that's ok, new features generally should anyway.
+
+None of these rules are inviolable, but you should have a good reason for any particular feature to deviate.
+
+This list is very far from being complete.
+
+
+## Number-taking inputs should reject `NaN`
+
+In any place which expects a number, receiving `NaN` - or anything which coerces to `NaN`, if coercion is performed - should throw a `RangeError`.
+
+Note that some abstract operations, like [ToIntegerOrInfinity](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tointegerorinfinity), [ToIndex](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toindex), etc, will coerce `NaN` to 0. So you'll need to coerce inputs before calling those operations, check for `NaN`, and then pass the coerced result to the operation.
+
+NB: This convention is new as of 2023, and most earlier parts of the language do not follow it.
+
+
+## If an argument is expected, not getting it or getting `undefined` should throw a `TypeError`
+
+When there is a required argument, finding that it is explicitly `undefined` or is missing should throw a `TypeError` instead of attempting to coerce `undefined` to the expected type. This extends to values looked up in options bags, etc. This does not apply when there is a default value for the argument, since in that case it is not required.
+
+This convention applies only to `undefined` specifically, and says nothing about the appropriate handling of values like `null` and `document.all`.
+
+NB: This convention is new as of 2023, and most earlier parts of the language do not follow it.
+

--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -10,7 +10,7 @@ This list is very far from being complete.
 
 If an argument to a built-in function is expected to be of a particular type other than Boolean, the function should throw a `TypeError` if called with a value not of that type, rather than performing coercion. This also applies to values read from options bags.
 
-For example, if a function takes a string and is called with a Number or an object, it should throw a `TypeError` rather than attempting to coerce those values to strings.
+For example, if a function takes a string and is called with a Number or an object, it should throw a `TypeError` rather than attempting to coerce those values to strings. Similarly, if a function takes an object and is called with a string, it should throw rather than e.g. looking up properties on the string.
 
 NB: This convention is new as of 2024, and most earlier parts of the language do not follow it.
 

--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -8,7 +8,7 @@ This list is very far from being complete.
 
 ## Number-taking inputs should reject `NaN`
 
-In any built-in function which expects a number (including as an option in an options bag), receiving `NaN` or anything which results in `NaN` after coercion is performed (such as by passing through `ToNumeric`, `ToPrimitive`, `ToNumber`, etc.) should cause a `RangeError` to be thrown.
+In any built-in function which expects a non-NaN number (including as an option in an options bag), receiving `NaN` or anything which results in `NaN` after coercion is performed (such as by passing through `ToNumeric`, `ToPrimitive`, `ToNumber`, etc.) should cause a `RangeError` to be thrown.
 
 Note that some abstract operations, like [ToIntegerOrInfinity](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tointegerorinfinity), [ToIndex](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toindex), etc, will coerce inputs to Number and then further coerce the result, sometimes including mapping `NaN` to non-`NaN` values. So you'll need to coerce inputs to a Number using `ToNumber` before calling those operations, check for `NaN`, and then pass the resulting Number to the operation.
 

--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -2,15 +2,17 @@
 
 This document describes some of the conventions that we try to follow when designing new features. Sometimes old features don't follow these; that's ok, new features generally should anyway.
 
-None of these rules are inviolable, but you should have a good reason for any particular feature to deviate.
+None of these rules are inviolable, but you should have a good reason for any particular feature to deviate (for example, because the feature is a close cousin of an existing feature, like `findLastIndex` vs `findIndex`).
 
 This list is very far from being complete.
 
 ## Number-taking inputs should reject `NaN`
 
-In any place which expects a number, receiving `NaN` - or anything which coerces to `NaN`, if coercion is performed - should throw a `RangeError`.
+In any built-in function which expects a number (including as an option in an options bag), receiving `NaN` or anything which results in `NaN` after coercion is performed (such as by passing through `ToNumeric`, `ToPrimitive`, `ToNumber`, etc.) should cause a `RangeError` to be thrown.
 
-Note that some abstract operations, like [ToIntegerOrInfinity](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tointegerorinfinity), [ToIndex](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toindex), etc, will coerce `NaN` to 0. So you'll need to coerce inputs before calling those operations, check for `NaN`, and then pass the coerced result to the operation.
+Note that some abstract operations, like [ToIntegerOrInfinity](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tointegerorinfinity), [ToIndex](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toindex), etc, will coerce inputs to Number and then further coerce the result, sometimes including mapping `NaN` to non-`NaN` values. So you'll need to coerce inputs to a Number using `ToNumber` before calling those operations, check for `NaN`, and then pass the resulting Number to the operation.
+
+An exception to this rule is functions which take optional numeric arguments: in that case, receiving `undefined` should be treated as the argument not being passed.
 
 NB: This convention is new as of 2023, and most earlier parts of the language do not follow it.
 

--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -6,7 +6,6 @@ None of these rules are inviolable, but you should have a good reason for any pa
 
 This list is very far from being complete.
 
-
 ## Avoid coercing arguments to types other than Boolean
 
 If an argument to a built-in function is expected to be of a particular type other than Boolean, the function should throw a `TypeError` if called with a value not of that type, rather than performing coercion. This also applies to values read from options bags.
@@ -14,7 +13,6 @@ If an argument to a built-in function is expected to be of a particular type oth
 For example, if a function takes a string and is called with a Number or an object, it should throw a `TypeError` rather than attempting to coerce those values to strings.
 
 NB: This convention is new as of 2024, and most earlier parts of the language do not follow it.
-
 
 ## When required arguments are missing, throw
 
@@ -24,13 +22,11 @@ This does not apply when there is a default value for the argument in question, 
 
 NB: This convention is new as of 2024, and most earlier parts of the language do not follow it.
 
-
 ## Number-taking inputs should reject `NaN`
 
 If an argument to a built-in function is expected to be a non-`NaN` Number (including as an option in an options bag), receiving `NaN` should cause a `RangeError` to be thrown.
 
 NB: This convention is new as of 2024, and most earlier parts of the language do not follow it.
-
 
 ## Integral-Number-taking inputs should reject non-integal arguments
 

--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -10,7 +10,7 @@ This list is very far from being complete.
 
 If an argument to a built-in function is expected to be of a particular type other than Boolean, the function should throw a `TypeError` if called with a value not of that type, rather than performing coercion. This also applies to values read from options bags.
 
-For example, if a function takes a string and is called with a Number or an object, it should throw a `TypeError` rather than attempting to coerce those values to strings. Similarly, if a function takes an object and is called with a string, it should throw rather than e.g. looking up properties on the string.
+For example, if a function expects a string and is called with a Number or an object, it should throw a `TypeError` rather than attempting to coerce those values to strings. Similarly, if a function takes an object and is called with a string, it should throw rather than e.g. looking up properties on the string.
 
 NB: This convention is new as of 2024, and most earlier parts of the language do not follow it.
 

--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -4,7 +4,7 @@ This document describes some of the conventions that we try to follow when desig
 
 None of these rules are inviolable, but you should have a good reason for any particular feature to deviate (for example, because the feature is a close cousin of an existing feature, like `findLastIndex` vs `findIndex`).
 
-This list is very far from being complete.
+This list will never cover all such conventions and is expected to grow over time.
 
 ## Avoid coercing arguments to types other than Boolean
 

--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -16,6 +16,18 @@ An exception to this rule is functions which take optional numeric arguments: in
 
 NB: This convention is new as of 2023, and most earlier parts of the language do not follow it.
 
+## Integer-taking inputs should reject non-integral numbers
+
+In any built-in function which expects an integral number (including as an option in an options bag), receiving a non-integral number or anything which results in a non-integral number after coercion is performed (such as by passing through `ToNumeric`, `ToPrimitive`, `ToNumber`, etc.) should cause a `RangeError` to be thrown.
+
+Note that some abstract operations, like [ToIntegerOrInfinity](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tointegerorinfinity), [ToIndex](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toindex), etc, will coerce inputs to Number and then further round the result. So you'll need to coerce inputs to a Number using `ToNumber` before calling those operations and then check for non-integral values, rather than using those operations.
+
+For the purposes of this guideline `-0` is considered to be an integral number (specifically, 0).
+
+Some APIs intentionally round non-integral inputs, for example as an attempt to provide a best-effort behavior, rather than because the API fundamentally only makes sense with integers. This guideline does not apply to those cases.
+
+NB: This convention is new as of 2023, and most earlier parts of the language do not follow it.
+
 ## If an argument is expected, not getting it or getting `undefined` should throw a `TypeError`
 
 When there is a required argument, finding that it is explicitly `undefined` or is missing should throw a `TypeError` instead of attempting to coerce `undefined` to the expected type. This extends to values looked up in options bags, etc. This does not apply when there is a default value for the argument, since in that case it is not required.

--- a/normative-conventions.md
+++ b/normative-conventions.md
@@ -30,7 +30,7 @@ NB: This convention is new as of 2024, and most earlier parts of the language do
 
 ## Integral-Number-taking inputs should reject non-integral arguments
 
-If an argument to a built-in function is expected to be a Number (including as an option in an options bag), receiving a non-integral Number should cause a `RangeError` to be thrown.
+If an argument to a built-in function is expected to be an integral Number (including as an option in an options bag), receiving a non-integral Number should cause a `RangeError` to be thrown.
 
 For the purposes of this guideline `-0` is considered to be an integral number (specifically, 0).
 


### PR DESCRIPTION
We got explicit consensus for these rules in the [July 2023](https://github.com/tc39/notes/blob/main/meetings/2023-07/july-13.md#stop-coercing-things), [September 2023](https://github.com/tc39/notes/blob/main/meetings/2023-09/september-28.md#stop-coercing-things-pt-2), [November 2023](https://github.com/tc39/notes/blob/main/meetings/2023-11/november-29.md#stop-coercing-things-pt-3), and April 2024 meetings (notes not yet available for the April 2024).

https://github.com/tc39/how-we-work/pull/119 would introduce a `spec-conventions.md`. [I think](https://github.com/tc39/how-we-work/pull/119#issuecomment-1490687831) we shouldn't mix normative with editorial conventions, so I've made a different document. But the sole normative convention currently in that PR would be good to include in this new document.