### PR TITLE
Document agenda rules

### DIFF
--- a/agenda.md
+++ b/agenda.md
@@ -1,0 +1,20 @@
+## Agenda topic best practices
+
+All TC39 agenda items should be posted on the agenda before the "agenda deadline", which is precisely 10 days before the start of the meeting. It's best to post agenda items as soon as you know you'll be presenting on the topic, even if you don't have all of the supporting materials yet.
+
+Before the agenda deadline, agenda items should be accompanied by supporting materials. Supporting materials includes slides, a link to the proposal repository, a link to spec text, etc.; essentially, anything you are planning to present to the committee, or that would be useful for delegates to review.
+
+Pull requests are encouraged for all agenda additions, especially for late additions after the deadline, so that members are notified of changes. All delegates have write access to the agenda, and should promptly land agenda additions so that they are maximally visible quickly.
+
+If agenda items or their supporting materials are added only after the agenda deadline, then TC39 is unlikely to reach consensus on that item. Many TC39 delegates review the agenda ahead of the meeting with their colleagues, in order to collect feedback to bring to the committee.
+
+TC39 may reach consensus on certain proposals whose supporting materials are added late, if a normative change is considered urgent. It's best to avoid this situation, however.
+
+Some types of supporting materials which are typically necessary based on the stage of the proposal, in addition to slides:
+- A Stage 1 proposal should explain the problem statement in a README.
+- Stage 2, 2.7, 3 and 4 proposals, as well as any consensus-seeking normative change, need spec text, in addition to a README explaining the proposal and its motivation in some detail.
+- Stage 4 proposals must link to a pull request into [the spec](https://github.com/tc39/ecma262), since the [process](https://tc39.github.io/process-document/) requires one.
+
+The TC39 agenda items about proposals are sorted primarily by stage (descending), secondarily by timebox (ascending), and finally by insertion date. Items may be reordered by chairs when running the meeting based on various constraints.
+
+Supporting materials includes slides, a link to the proposal repository, a link to spec text, etc.; essentially, anything you are planning to present to the committee, or that would be useful for delegates to review.


### PR DESCRIPTION
A reframing of the agenda rules, from the template, encouraging people to add things sooner.