### PR TITLE
Change "prose contributions" to "arguments and opinions"

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -2,7 +2,7 @@
 
 This policy applies to prose contributions (e.g., ideas, comments, issues, etc.). It does not apply to code contributions, which are evaluated through our review processes.
 
-Prose contributions and comments must be your own writing, not the product of large language models (LLMs) or other tools. Do not prompt an LLM to expand on or explain your idea and then post the output; just provide the idea itself.
+Convey arguments and opinions in your own writing, not the writing of large language models (LLMs) or other tools. Do not prompt an LLM to expand on or explain your idea and then post the output; just provide the idea itself.
 
 Machine translation is permissible, including translation by an LLM, but your use of translation should not introduce any new content.
 


### PR DESCRIPTION
There are situations where AI usage should not be allowed:

- Expanding a thought from a prompt to a paragraph. Just post the prompt!
    - Explanation: We all have access to the same LLM tools and can expand on the thought ourselves. We don't need your LLM to do it.

There are situations where AI usage is allowed:

- Machine translation
- Proofreading, so long as the proofreading avoids adding new content

And then there are situations which we haven't specifically evaluated yet:

- Can an LLM be used to do research and post the output of that research?
- Can an LLM be used to post data involving a nicely formatted graph or table?
- Can an LLM be used to triage issues; for example, taking an issue whose comments went in multiple directions and spawning multiple sub-issues summarizing the comments?

I prefer to leave the door open for such use cases, and add them to the policy when necessary. To achieve this, I am proposing to change the policy wording from the broad "prose contributions" to the more specific "arguments and opinions", which I think better captures the spirit and intent of why we originally made this policy.